### PR TITLE
Fix a broken link in the demo

### DIFF
--- a/templates/chat/about.html
+++ b/templates/chat/about.html
@@ -5,8 +5,8 @@
   <p class="deck">
     This is a demo using <a href="http://channels.readthedocs.org/en/latest/">
     Django Channels</a> to implement a simple WebSocket-based chat server.
-    You can see the <a href="https://github.com/jacobian/channels-
-    example">code on GitHub</a>, or try the app:
+    You can see the <a href="https://github.com/jacobian/channels-example">
+    code on GitHub</a>, or try the app:
   </p>
   <p>
     <a class="button button-primary" href="{% url 'new_room' %}">Create new chat room</a>


### PR DESCRIPTION
The wrapping was causing a bunch of spaces to be jammed in (at least on
Chrome).

Ex: https://github.com/jacobian/channels-%20%20%20%20example
