### PR TITLE
Added semicolons after every statement in chat.js

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -5,20 +5,20 @@ $(function() {
     
     chatsock.onmessage = function(message) {
         var data = JSON.parse(message.data);
-        var chat = $("#chat")
-        var ele = $('<tr></tr>')
+        var chat = $("#chat");
+        var ele = $('<tr></tr>');
 
         ele.append(
             $("<td></td>").text(data.timestamp)
-        )
+        );
         ele.append(
             $("<td></td>").text(data.handle)
-        )
+        );
         ele.append(
             $("<td></td>").text(data.message)
-        )
+        );
         
-        chat.append(ele)
+        chat.append(ele);
     };
 
     $("#chatform").on("submit", function(event) {


### PR DESCRIPTION
You should use semicolons after every statement in JavaScript.