### PR TITLE
text is an undefined variable use message['text']

### DIFF
--- a/chat/consumers.py
+++ b/chat/consumers.py
@@ -53,7 +53,7 @@ def ws_receive(message):
     try:
         data = json.loads(message['text'])
     except ValueError:
-        log.debug("ws message isn't json text=%s", text)
+        log.debug("ws message isn't json text=%s", message['text'])
         return
     
     if set(data.keys()) != set(('handle', 'message')):


### PR DESCRIPTION
In [consumers.py > ws_receive - line 56](https://github.com/jacobian/channels-example/blob/master/chat/consumers.py#L56) if exception occurred the log is using `text` variable which is undefined we need to use `message['text']` instead.

```
    try:
        data = json.loads(message['text'])
    except ValueError:
        log.debug("ws message isn't json text=%s", text)  #<-- we need to use message['text'] here
        return
```